### PR TITLE
NIFI-11362 Fixed Flaky Test in TestValidateRecord.java

### DIFF
--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateRecord.java
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/src/test/java/org/apache/nifi/processors/standard/TestValidateRecord.java
@@ -522,20 +522,6 @@ public class TestValidateRecord {
         final MockFlowFile validFlowFile = runner.getFlowFilesForRelationship(ValidateRecord.REL_VALID).get(0);
         validFlowFile.assertContentEquals(new File("src/test/resources/TestValidateRecord/timestamp.json"));
 
-        // Test with a timestamp that has an invalid format.
-        runner.clearTransferState();
-
-        runner.disableControllerService(jsonReader);
-        runner.setProperty(jsonReader, DateTimeUtils.TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss");
-        runner.enqueue(Paths.get("src/test/resources/TestValidateRecord/timestamp.json"));
-        runner.enableControllerService(jsonReader);
-
-        runner.run();
-
-        runner.assertTransferCount(ValidateRecord.REL_INVALID, 1);
-        final MockFlowFile invalidFlowFile = runner.getFlowFilesForRelationship(ValidateRecord.REL_INVALID).get(0);
-        invalidFlowFile.assertContentEquals(new File("src/test/resources/TestValidateRecord/timestamp.json"));
-
         // Test with an Inferred Schema.
         runner.disableControllerService(jsonReader);
         runner.setProperty(jsonReader, SchemaAccessUtils.SCHEMA_ACCESS_STRATEGY, SchemaInferenceUtil.INFER_SCHEMA.getValue());
@@ -549,6 +535,20 @@ public class TestValidateRecord {
         runner.assertTransferCount(ValidateRecord.REL_VALID, 1);
         final MockFlowFile validFlowFileInferredSchema = runner.getFlowFilesForRelationship(ValidateRecord.REL_VALID).get(0);
         validFlowFileInferredSchema.assertContentEquals(new File("src/test/resources/TestValidateRecord/timestamp.json"));
+        
+        // Test with a timestamp that has an invalid format.
+        runner.clearTransferState();
+
+        runner.disableControllerService(jsonReader);
+        runner.setProperty(jsonReader, DateTimeUtils.TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss");
+        runner.enqueue(Paths.get("src/test/resources/TestValidateRecord/timestamp.json"));
+        runner.enableControllerService(jsonReader);
+
+        runner.run();
+
+        runner.assertTransferCount(ValidateRecord.REL_INVALID, 1);
+        final MockFlowFile invalidFlowFile = runner.getFlowFilesForRelationship(ValidateRecord.REL_INVALID).get(0);
+        invalidFlowFile.assertContentEquals(new File("src/test/resources/TestValidateRecord/timestamp.json"));
     }
 
     @Test


### PR DESCRIPTION
[NIFI-11362](https://issues.apache.org/jira/browse/NIFI-11362)

### What is the purpose of this PR:
This PR fixes the flaky test testValidateJsonTimestamp in TestValidateRecord.java.
Since the commit where this test was created, the test has been flaky.

### Why the test fails:
The testValidateJsonTimestamp fails because two individual tests inside testValidateJsonTimestamp are order dependent:
-Test with a timestamp that has an invalid format and -Test with an Inferred Schema.

### Reproduce the test failure:
Run the tests with NonDex maven plugin. The commands to recreate the flaky test failures are:

mvn -pl nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.nifi.processors.standard.TestValidateRecord#testValidateJsonTimestamp

### Expected Result
testValidateJsonTimestamp must run successfully when run with NonDex.

### Actual Result
Failures: 
TestValidateRecord.testValidateJsonTimestamp:549 expected: <1> but was: <0> 
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

### Fix
Inside testValidateJsonTimestamp, reverse the order of these tests:
-Test with a timestamp that has an invalid format
-Test with an Inferred Schema.

### Build
- Build completed using mvn clean install -DskipTests -pl nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors -am
- JDK 11.0.18
- Maven 3.8.1. 

